### PR TITLE
feat: 이미지 생성/합성 파이프라인 초기 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    
+
+    // 외부 API 호출을 위해 WebClient 불러오기용
+    implementation 'org.springframework:spring-webflux'
+
+
     // Security & Authentication
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
@@ -57,6 +61,12 @@ dependencies {
     implementation 'org.springframework.modulith:spring-modulith-starter-core'
     implementation 'org.springframework.modulith:spring-modulith-starter-jpa'
     implementation 'org.springframework.modulith:spring-modulith-events-api'
+
+    // WebClient
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // Netty HttpClient
+    implementation 'io.projectreactor.netty:reactor-netty-http'
     
     // Code Generation & Processing
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/example/nomodel/_core/config/SecurityConfig.java
+++ b/src/main/java/com/example/nomodel/_core/config/SecurityConfig.java
@@ -71,34 +71,57 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
 
-        httpSecurity.csrf(AbstractHttpConfigurer::disable)
-                .cors(cors -> cors.configurationSource(corsConfigurationSource()))  // CORS 설정 추가
-                .sessionManagement((sessionManagement) ->
-                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests((request) -> request
-                        // Actuator endpoints 먼저 허용 (JWT 필터보다 우선)
-                        .requestMatchers("/api/actuator/**").permitAll()
-                        .requestMatchers("/actuator/**").permitAll()
-                        // 나머지 WHITE_LIST 허용
+        httpSecurity
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        // 프리플라이트 허용
+                        .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll()
+
+                        // Actuator 허용(이미 있음)
+                        .requestMatchers("/api/actuator/**", "/actuator/**").permitAll()
+
+                        // 파일/생성 파이프라인 허용 (프론트 연동용)
+                        .requestMatchers("/api/generate/**", "/api/files/**", "/generate/**", "/files/**").permitAll()
+
+                        // 보안 화이트리스트
+                        .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll()
+
+
+                        // Swagger 허용 (context-path 유무 모두 커버)
+                        .requestMatchers(
+                                "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html",
+                                "/api/swagger-ui/**", "/api/v3/api-docs/**"
+                        ).permitAll()
+
+                        // 기존 화이트리스트 유지
                         .requestMatchers(WHITE_LIST).permitAll()
-                        // 관리자 권한 필요
+
+                        // 관리자/차단 경로 규칙 유지
                         .requestMatchers(ADMIN_LIST).hasAuthority("ADMIN")
-                        // 금지된 경로
                         .requestMatchers(BAN_LIST).denyAll()
-                        // 나머지는 인증 필요
-                        .anyRequest().authenticated())
-                .anonymous(anonymous -> anonymous.authorities("ROLE_ANONYMOUS"))
-                .headers(AbstractHttpConfigurer::disable  // H2 콘솔에서 프레임 사용 허용
+
+                        // 그 외 인증 필요
+                        .anyRequest().authenticated()
                 )
-                .exceptionHandling(exception -> {
-                    exception.authenticationEntryPoint(authenticationEntryPoint());
-                    exception.accessDeniedHandler(accessDeniedHandler());
+                .anonymous(anonymous -> anonymous.authorities("ROLE_ANONYMOUS"))
+
+                .headers(headers -> headers
+                        .frameOptions(frame -> frame.disable())
+                )
+
+                .exceptionHandling(ex -> {
+                    ex.authenticationEntryPoint(authenticationEntryPoint());
+                    ex.accessDeniedHandler(accessDeniedHandler());
                 })
-                // JWT 필터 활성화
+
+                // JWT 필터
                 .addFilterBefore(new JWTTokenFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
 
         return httpSecurity.build();
     }
+
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {

--- a/src/main/java/com/example/nomodel/_core/config/WebClientConfig.java
+++ b/src/main/java/com/example/nomodel/_core/config/WebClientConfig.java
@@ -1,0 +1,68 @@
+package com.example.nomodel._core.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+import java.time.Duration;
+
+@Configuration
+public class WebClientConfig {
+
+    /** remove.bg 용 WebClient — BG_PROVIDER=removebg 일 때만 생성 */
+    @Bean(name = "removeBgWebClient")
+    @ConditionalOnProperty(name = "BG_PROVIDER", havingValue = "removebg")
+    public WebClient removeBgWebClient(
+            @Value("${REMOVEBG_API_BASE_URL}") String baseUrl,
+            @Value("${REMOVEBG_API_KEY}") String apiKey,
+            @Value("${BG_TIMEOUT_SEC:60}") long timeoutSec
+    ) {
+        HttpClient http = HttpClient.create().responseTimeout(Duration.ofSeconds(timeoutSec));
+        return WebClient.builder()
+                .baseUrl(baseUrl)
+                .clientConnector(new ReactorClientHttpConnector(http))
+                .defaultHeader("X-Api-Key", apiKey)
+                .exchangeStrategies(ExchangeStrategies.builder()
+                        .codecs(c -> c.defaultCodecs().maxInMemorySize(20 * 1024 * 1024))
+                        .build())
+                .build();
+    }
+
+    /** Gemini 용 WebClient — BG_PROVIDER=gemini 일 때만 생성 */
+    @Bean(name = "geminiWebClient")
+    @ConditionalOnProperty(name = "BG_PROVIDER", havingValue = "gemini")
+    public WebClient geminiWebClient(
+            @Value("${GEMINI_API_BASE_URL}") String baseUrl,
+            @Value("${GEMINI_API_KEY}") String apiKey,
+            @Value("${BG_TIMEOUT_SEC:60}") long timeoutSec
+    ) {
+        HttpClient http = HttpClient.create().responseTimeout(Duration.ofSeconds(timeoutSec));
+        return WebClient.builder()
+                .baseUrl(baseUrl)
+                .clientConnector(new ReactorClientHttpConnector(http))
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
+                .exchangeStrategies(ExchangeStrategies.builder()
+                        .codecs(c -> c.defaultCodecs().maxInMemorySize(20 * 1024 * 1024))
+                        .build())
+                .build();
+    }
+
+    @Bean
+    public WebClient replicateWebClient(
+            @Value("${REPLICATE_API_BASE_URL}") String baseUrl,
+            @Value("${REPLICATE_API_TOKEN}") String token
+    ) {
+        return WebClient.builder()
+                .baseUrl(baseUrl)
+                .defaultHeader("Authorization", "Token " + token)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/nomodel/compose/application/controller/ComposeController.java
+++ b/src/main/java/com/example/nomodel/compose/application/controller/ComposeController.java
@@ -1,0 +1,28 @@
+package com.example.nomodel.compose.application.controller;
+
+import com.example.nomodel.compose.application.dto.ComposeRequest;
+import com.example.nomodel.compose.application.dto.ComposeResponse;
+import com.example.nomodel.generationjob.application.service.GenerationJobService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/generate")
+public class ComposeController {
+
+    private final GenerationJobService jobService;
+
+    @PostMapping("/compose")
+    public ResponseEntity<?> compose(@RequestBody ComposeRequest req,
+                                     @RequestHeader(name="X-User-Id", required=false) Long userId) {
+        String jobId = jobService.enqueueCompose(
+                userId == null ? 0L : userId,
+                req.fileId(),
+                req.prompt(),
+                req.mode()
+        );
+        return ResponseEntity.accepted().body(new ComposeResponse(jobId));
+    }
+}

--- a/src/main/java/com/example/nomodel/compose/application/dto/ComposeRequest.java
+++ b/src/main/java/com/example/nomodel/compose/application/dto/ComposeRequest.java
@@ -1,0 +1,9 @@
+package com.example.nomodel.compose.application.dto;
+
+import com.example.nomodel.generationjob.domain.model.GenerationMode;
+
+public record ComposeRequest(
+        Long fileId,        // 누끼 PNG fileId
+        String prompt,      // 장면/인물 프롬프트
+        GenerationMode mode // SCENE | SUBJECT_SCENE
+) {}

--- a/src/main/java/com/example/nomodel/compose/application/dto/ComposeResponse.java
+++ b/src/main/java/com/example/nomodel/compose/application/dto/ComposeResponse.java
@@ -1,0 +1,3 @@
+package com.example.nomodel.compose.application.dto;
+
+public record ComposeResponse(String jobId) {}

--- a/src/main/java/com/example/nomodel/compose/application/service/provider/DummyImageCompositor.java
+++ b/src/main/java/com/example/nomodel/compose/application/service/provider/DummyImageCompositor.java
@@ -1,0 +1,15 @@
+package com.example.nomodel.compose.application.service.provider;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+@Service
+@ConditionalOnProperty(name = "COMPOSITOR_PROVIDER", havingValue = "dummy", matchIfMissing = true)
+public class DummyImageCompositor implements ImageCompositor {
+    @Override
+    public byte[] composite(byte[] scene, byte[] cutout) {
+        // 합성기는 다음 단계에서 실제로 구현.
+        // 지금은 파이프라인만 확인하므로 scene 그대로 반환.
+        return scene;
+    }
+}

--- a/src/main/java/com/example/nomodel/compose/application/service/provider/ImageCompositor.java
+++ b/src/main/java/com/example/nomodel/compose/application/service/provider/ImageCompositor.java
@@ -1,0 +1,10 @@
+package com.example.nomodel.compose.application.service.provider;
+
+public interface ImageCompositor {
+    /**
+     * @param scene   장면(배경) 이미지
+     * @param cutout  누끼 PNG(알파 포함)
+     * @return        합성 결과 (PNG 권장)
+     */
+    byte[] composite(byte[] scene, byte[] cutout) throws Exception;
+}

--- a/src/main/java/com/example/nomodel/file/application/controller/FileController.java
+++ b/src/main/java/com/example/nomodel/file/application/controller/FileController.java
@@ -1,0 +1,61 @@
+package com.example.nomodel.file.application.controller;
+
+import com.example.nomodel.file.application.service.FileService;
+import com.example.nomodel.file.domain.model.FileType;
+import com.example.nomodel.file.domain.model.RelationType;
+import com.example.nomodel.file.domain.model.File;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/files")
+public class FileController {
+
+    private final FileService fileService;
+
+    /** 업로드 */
+    @PostMapping
+    public ResponseEntity<?> upload(@RequestParam("file") MultipartFile file) throws Exception {
+        Long fileId = fileService.saveFile(file, RelationType.AD, 0L, FileType.PREVIEW); // 임시 관계
+        return ResponseEntity.ok().body(java.util.Map.of("fileId", fileId));
+    }
+
+    /** 파일 바이너리 조회 (브라우저에서 바로 보기) */
+    @GetMapping("/{fileId}")
+    public ResponseEntity<byte[]> view(@PathVariable Long fileId) throws Exception {
+        File meta = fileService.getMeta(fileId);          // FileService에 getMeta(Long) 존재해야 함
+        byte[] bytes = fileService.loadAsBytes(fileId);   // FileService에 loadAsBytes(Long) 존재해야 함
+
+        String contentType = meta.getContentType() != null
+                ? meta.getContentType()
+                : MediaType.APPLICATION_OCTET_STREAM_VALUE;
+        String fileName = meta.getFileName() != null ? meta.getFileName() : (fileId + "");
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(contentType))
+                .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + fileName + "\"")
+                .body(bytes);
+    }
+
+    /** 파일 메타데이터만 JSON으로 조회 (디버깅/프론트 용) */
+    @GetMapping("/{fileId}/meta")
+    public ResponseEntity<?> meta(@PathVariable Long fileId) {
+        File meta = fileService.getMeta(fileId);
+        return ResponseEntity.ok(java.util.Map.of(
+                "id", meta.getId(),
+                "fileName", meta.getFileName(),
+                "fileUrl", meta.getFileUrl(),
+                "contentType", meta.getContentType(),
+                "relationType", meta.getRelationType().name(),
+                "relationId", meta.getRelationId(),
+                "fileType", meta.getFileType().name(),
+                "createdAt", meta.getCreatedAt(),
+                "updatedAt", meta.getUpdatedAt()
+        ));
+    }
+}

--- a/src/main/java/com/example/nomodel/file/application/service/FileService.java
+++ b/src/main/java/com/example/nomodel/file/application/service/FileService.java
@@ -1,0 +1,111 @@
+package com.example.nomodel.file.application.service;
+
+import com.example.nomodel.file.domain.model.File;
+import com.example.nomodel.file.domain.model.FileType;
+import com.example.nomodel.file.domain.model.RelationType;
+import com.example.nomodel.file.domain.repository.FileJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import com.example.nomodel.file.domain.model.File;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class FileService {
+
+    private final FileJpaRepository fileJpaRepository;
+
+    private final String BASE_PATH = "uploads"; // 로컬 저장 경로 (임시)
+
+    /**
+     * MultipartFile 저장
+     */
+    @Transactional
+    public Long saveFile(MultipartFile multipartFile,
+                         RelationType relationType,
+                         Long relationId,
+                         FileType fileType) throws IOException {
+
+        // 1. 로컬 디렉토리 없으면 생성
+        java.io.File dir = new java.io.File(BASE_PATH);
+        if (!dir.exists()) dir.mkdirs();
+
+        // 2. 저장 파일명 (UUID + 확장자)
+        String originalName = multipartFile.getOriginalFilename();
+        String ext = originalName != null && originalName.contains(".")
+                ? originalName.substring(originalName.lastIndexOf("."))
+                : "";
+        String savedName = UUID.randomUUID() + ext;
+
+        Path savePath = Paths.get(BASE_PATH, savedName);
+
+        // 3. 파일 저장
+        multipartFile.transferTo(savePath);
+
+        // 4. DB 저장
+        File fileEntity = File.createFileWithContentType(
+                relationType,
+                relationId,
+                savePath.toString(),
+                savedName,
+                fileType,
+                multipartFile.getContentType()
+        );
+        File saved = fileJpaRepository.save(fileEntity);
+
+        return saved.getId();
+    }
+
+    /**
+     * 바이트 배열 저장 (예: Gemini 결과물)
+     */
+    @Transactional
+    public Long saveBytes(byte[] data,
+                          String contentType,
+                          RelationType relationType,
+                          Long relationId,
+                          FileType fileType) throws IOException {
+
+        java.io.File dir = new java.io.File(BASE_PATH);
+        if (!dir.exists()) dir.mkdirs();
+
+        String savedName = UUID.randomUUID() + ".png";
+        Path savePath = Paths.get(BASE_PATH, savedName);
+        Files.write(savePath, data);
+
+        File fileEntity = File.createFileWithContentType(
+                relationType,
+                relationId,
+                savePath.toString(),
+                savedName,
+                fileType,
+                contentType
+        );
+        File saved = fileJpaRepository.save(fileEntity);
+
+        return saved.getId();
+    }
+
+    /**
+     * 파일 로드
+     */
+    @Transactional(readOnly = true)
+    public byte[] loadAsBytes(Long fileId) throws IOException {
+        File file = fileJpaRepository.findById(fileId)
+                .orElseThrow(() -> new IllegalArgumentException("File not found: " + fileId));
+        Path path = Paths.get(file.getFileUrl());
+        return Files.readAllBytes(path);
+    }
+
+    @Transactional(readOnly = true)
+    public File getMeta(Long fileId) {
+        return fileJpaRepository.findById(fileId)
+                .orElseThrow(() -> new IllegalArgumentException("File not found: " + fileId));
+    }
+}
+

--- a/src/main/java/com/example/nomodel/generate/application/service/provider/DummyImageGenerator.java
+++ b/src/main/java/com/example/nomodel/generate/application/service/provider/DummyImageGenerator.java
@@ -1,0 +1,27 @@
+package com.example.nomodel.generate.application.service.provider;
+
+import com.example.nomodel.generationjob.domain.model.GenerationMode;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import java.util.Base64;
+import java.util.Map;
+
+/**
+ * 실제 모델 호출 전 파이프라인 점검용 더미 생성기.
+ * GEN_PROVIDER=dummy 이거나(권장) 생성기 Bean이 전혀 없을 때 자동 활성화.
+ */
+@Service
+public class DummyImageGenerator implements ImageGenerator {
+
+    // 1x1 transparent PNG
+    private static final byte[] PNG_1x1_TRANSPARENT = Base64.getDecoder().decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMBDQf2rCQAAAAASUVORK5CYII="
+    );
+
+    @Override
+    public byte[] generate(GenerationMode mode, String prompt, Map<String, Object> opts) {
+        return PNG_1x1_TRANSPARENT;
+    }
+}

--- a/src/main/java/com/example/nomodel/generate/application/service/provider/ImageGenerator.java
+++ b/src/main/java/com/example/nomodel/generate/application/service/provider/ImageGenerator.java
@@ -1,0 +1,14 @@
+package com.example.nomodel.generate.application.service.provider;
+
+import com.example.nomodel.generationjob.domain.model.GenerationMode;
+import java.util.Map;
+
+public interface ImageGenerator {
+    /**
+     * @param mode   SCENE | SUBJECT | SUBJECT_SCENE
+     * @param prompt 전체 프롬프트(장면/인물/의상/분위기 등 통합)
+     * @param opts   model, size, seed, control 옵션 등
+     * @return       생성 결과 이미지 바이트 (PNG/JPEG)
+     */
+    byte[] generate(GenerationMode mode, String prompt, Map<String, Object> opts) throws Exception;
+}

--- a/src/main/java/com/example/nomodel/generate/application/service/provider/ReplicateImageGenerator.java
+++ b/src/main/java/com/example/nomodel/generate/application/service/provider/ReplicateImageGenerator.java
@@ -1,0 +1,111 @@
+package com.example.nomodel.generate.application.service.provider;
+
+import com.example.nomodel.generationjob.domain.model.GenerationMode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "GEN_PROVIDER", havingValue = "replicate")
+public class ReplicateImageGenerator implements ImageGenerator {
+
+    private final WebClient replicateWebClient;
+
+    @Value("${REPLICATE_MODEL_VERSION}")
+    private String modelVersion;
+
+    @Value("${GEN_TIMEOUT_SEC:120}")
+    private long timeoutSec;
+
+    @Value("${GEN_RETRY_MAX:1}")
+    private int retryMax;
+
+    @Override
+    public byte[] generate(GenerationMode mode, String prompt, Map<String, Object> opts) throws Exception {
+        // 1) prediction 생성
+        var createReq = Map.of(
+                "version", modelVersion,
+                "input", Map.of(
+                        "prompt", buildPrompt(mode, prompt),
+                        // 모델별 옵션: size/aspect_ratio/seed/num_outputs 등
+                        "aspect_ratio", opts.getOrDefault("aspect_ratio", "9:16"),
+                        "output_format", "png"
+                )
+        );
+
+        var created = replicateWebClient.post()
+                .uri("/v1/predictions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(createReq)
+                .retrieve()
+                .onStatus(s -> !s.is2xxSuccessful(), r -> r.bodyToMono(String.class)
+                        .flatMap(b -> Mono.error(new RuntimeException("Replicate create error: " + b))))
+                .bodyToMono(Map.class)
+                .timeout(Duration.ofSeconds(timeoutSec))
+                .retry(retryMax)
+                .block();
+
+        String id = (String)((Map<?,?>)created).get("id");
+
+        // 2) 폴링
+        Map<?,?> polled;
+        while (true) {
+            polled = replicateWebClient.get()
+                    .uri("/v1/predictions/{id}", id)
+                    .retrieve()
+                    .onStatus(s -> !s.is2xxSuccessful(), r -> r.bodyToMono(String.class)
+                            .flatMap(b -> Mono.error(new RuntimeException("Replicate get error: " + b))))
+                    .bodyToMono(Map.class)
+                    .timeout(Duration.ofSeconds(timeoutSec))
+                    .retry(retryMax)
+                    .block();
+
+            String status = String.valueOf(polled.get("status"));
+            if ("succeeded".equals(status)) break;
+            if ("failed".equals(status) || "canceled".equals(status)) {
+                throw new RuntimeException("Replicate prediction failed: " + status + " / " + polled);
+            }
+            Thread.sleep(1600);
+        }
+
+        // 3) 결과 URL -> 바이트 다운로드
+        var output = (List<?>) polled.get("output");
+        if (output == null || output.isEmpty()) {
+            throw new RuntimeException("Replicate empty output");
+        }
+        String url = String.valueOf(output.get(0));
+        // 이미지 다운로드
+        return replicateWebClient.get()
+                .uri(URI.create(url))
+                .accept(MediaType.ALL)
+                .retrieve()
+                .bodyToMono(ByteArrayResource.class)
+                .map(ByteArrayResource::getByteArray)
+                .timeout(Duration.ofSeconds(timeoutSec))
+                .retry(retryMax)
+                .block();
+    }
+
+    /** 모드에 맞춰 프롬프트를 살짝 보정 */
+    private String buildPrompt(GenerationMode mode, String userPrompt) {
+        String base = (userPrompt == null ? "" : userPrompt);
+        if (mode == null) mode = GenerationMode.SCENE;
+
+        return switch (mode) {
+            case SCENE -> base + ", no text, high detail background, product area reserved";
+            case SUBJECT_SCENE -> base + ", human model included, natural lighting, studio-quality, no text";
+            default -> base + ", no text"; // 누락된 모드 대비 기본 처리
+        };
+    }
+}

--- a/src/main/java/com/example/nomodel/generationjob/application/controller/JobQueryController.java
+++ b/src/main/java/com/example/nomodel/generationjob/application/controller/JobQueryController.java
@@ -1,0 +1,26 @@
+package com.example.nomodel.generationjob.application.controller;
+
+import com.example.nomodel.generationjob.application.service.GenerationJobService;
+import com.example.nomodel.generationjob.application.dto.JobViewResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequestMapping("/generate/jobs") // 현재 서버 context-path가 /api 이므로 최종 /api/api/generate/jobs
+@RequiredArgsConstructor
+public class JobQueryController {
+
+    private final GenerationJobService jobs;
+
+    @GetMapping("/{jobId}")
+    public ResponseEntity<?> view(@PathVariable UUID jobId) {
+        log.info("GET job {}", jobId);
+        var job = jobs.view(jobId);          // 404 처리됨
+        return ResponseEntity.ok(JobViewResponse.from(job));
+    }
+}

--- a/src/main/java/com/example/nomodel/generationjob/application/dto/JobViewResponse.java
+++ b/src/main/java/com/example/nomodel/generationjob/application/dto/JobViewResponse.java
@@ -1,0 +1,29 @@
+package com.example.nomodel.generationjob.application.dto;
+
+import com.example.nomodel.generationjob.domain.model.GenerationJob;
+import com.example.nomodel.generationjob.domain.model.JobStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record JobViewResponse(
+        UUID jobId,
+        JobStatus status,
+        Long inputFileId,
+        Long resultFileId,
+        String errorMessage,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static JobViewResponse from(GenerationJob j) {
+        return new JobViewResponse(
+                j.getId(),
+                j.getStatus(),
+                j.getInputFileId(),
+                j.getResultFileId(),
+                j.getErrorMessage(),
+                j.getCreatedAt(),
+                j.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/nomodel/generationjob/application/service/GenerationJobService.java
+++ b/src/main/java/com/example/nomodel/generationjob/application/service/GenerationJobService.java
@@ -1,0 +1,104 @@
+package com.example.nomodel.generationjob.application.service;
+
+import com.example.nomodel.file.application.service.FileService;
+import com.example.nomodel.file.domain.model.FileType;
+import com.example.nomodel.file.domain.model.RelationType;
+import com.example.nomodel.generate.application.service.provider.ImageGenerator;
+import com.example.nomodel.generationjob.domain.model.GenerationMode;
+import com.example.nomodel.generationjob.domain.model.GenerationJob;
+import com.example.nomodel.generationjob.domain.model.JobStatus;
+import com.example.nomodel.generationjob.domain.model.JobType;
+import com.example.nomodel.generationjob.domain.repository.GenerationJobRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class GenerationJobService {
+
+    private final GenerationJobRepository repo;
+    private final FileService fileService;
+    private final ImageGenerator imageGenerator; // replicate/dummy 중 활성 빈
+
+    /** remove-bg 잡 큐잉 */
+    @Transactional
+    public GenerationJob enqueueRemoveBg(Long ownerId, Long fileId, String paramsJson) {
+        GenerationJob job = GenerationJob.createRemoveBgJob(ownerId, fileId);
+        job.setParameters(paramsJson);
+        return repo.save(job);
+    }
+
+    /** 잡 단건 조회 */
+    @Transactional(readOnly = true)
+    public GenerationJob view(UUID jobId) {
+        return repo.findById(jobId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "Job not found: " + jobId));
+    }
+
+    /** compose(배경/인물+배경 생성) 잡 큐잉 */
+    @Transactional
+    public String enqueueCompose(Long userId, Long fileId, String prompt, GenerationMode mode) {
+        GenerationJob job = GenerationJob.createComposeJob(userId, fileId);
+        job.setComposeParams(prompt, mode);
+        repo.save(job);
+
+        // 간단 구현: 즉시 실행(동기). 비동기화하려면 runCompose에 @Async 부여 + 프록시 통해 호출 필요.
+        runCompose(job.getId(), prompt, mode);
+
+        return job.getId().toString();
+    }
+
+    /** compose 실행 로직 */
+    @Transactional
+    public void runCompose(UUID jobId, String prompt, GenerationMode mode) {
+        GenerationJob job = repo.findById(jobId).orElseThrow();
+        job.markRunning();
+        try {
+            // (1) 누끼 PNG 바이트 (다음 단계 인페인팅 합성에 사용 예정)
+            byte[] cutout = fileService.loadAsBytes(job.getInputFileId());
+
+            // (2) 배경 or 인물+배경 생성
+            Map<String, Object> opts = Map.of(
+                    "aspect_ratio", "9:16" // 필요 시 옵션 확장
+            );
+            byte[] base = imageGenerator.generate(mode, prompt, opts);
+
+            // (3) (임시) 합성 전: 생성 이미지를 그대로 저장
+            Long resultId = fileService.saveBytes(
+                    base, "image/png", RelationType.AD, job.getInputFileId(), FileType.PREVIEW
+            );
+
+            job.succeed(resultId);
+        } catch (Exception e) {
+            job.fail(e.getMessage());
+        }
+        // 트랜잭션 종료 시점에 JPA dirty checking으로 flush
+    }
+
+    /** remove-bg 실행 로직 (비동기) */
+    @Async
+    @Transactional
+    public void runRemoveBg(
+            UUID jobId,
+            java.util.function.BiFunction<Long, Map<String, Object>, Long> worker,
+            Map<String, Object> params
+    ) {
+        GenerationJob job = repo.findById(jobId).orElseThrow();
+        try {
+            job.markRunning();
+            Long outFileId = worker.apply(job.getInputFileId(), params); // 입력 fileId -> 결과 fileId
+            job.succeed(outFileId);
+        } catch (Exception e) {
+            job.fail(e.getMessage());
+        }
+        // 트랜잭션 종료 시점에 저장
+    }
+}

--- a/src/main/java/com/example/nomodel/generationjob/domain/model/GenerationJob.java
+++ b/src/main/java/com/example/nomodel/generationjob/domain/model/GenerationJob.java
@@ -1,0 +1,143 @@
+package com.example.nomodel.generationjob.domain.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.*;
+
+/**
+ * 생성 잡(누끼/합성 등) 공용 엔티티
+ */
+@Entity
+@Table(
+        name = "generation_job",
+        indexes = {
+                @Index(name = "ix_job_owner", columnList = "ownerId"),
+                @Index(name = "ix_job_status_createdAt", columnList = "status, createdAt")
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GenerationJob {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    /** 요청자(회원) */
+    @Column(nullable = false)
+    private Long ownerId;
+
+    /** 잡 종류: REMOVE_BG, COMPOSE ... */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private JobType type;
+
+    /** 입력 파일 (원본/누끼 등 파이프라인 입력) */
+    @Column(nullable = false)
+    private Long inputFileId;
+
+    /** 합성 시 사용할 모델 아이디(선택) */
+    private Long modelId;
+
+    /** 파라미터 JSON(선택) */
+    @Lob
+    @Column(columnDefinition = "text")
+    private String parameters;
+
+    /** 잡 상태 */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private JobStatus status;
+
+    /** 결과 파일 id */
+    private Long resultFileId;
+
+    /** 에러 메시지 */
+    @Column(length = 1000)
+    private String errorMessage;
+
+    /** 재시도 횟수 */
+    @Column(nullable = false)
+    private int retryCount;
+
+    /** 생성/수정 시각 */
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    /** 합성(배경/인물+배경) 프롬프트 */
+    @Column(name = "prompt", columnDefinition = "TEXT")
+    private String prompt;
+
+    /** 합성 모드: SCENE | SUBJECT_SCENE ... */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mode", length = 20)
+    private GenerationMode mode;
+
+    /* ====================== 라이프사이클 ====================== */
+
+    @PrePersist
+    void prePersist() {
+        createdAt = updatedAt = LocalDateTime.now();
+        if (status == null) status = JobStatus.PENDING;
+    }
+
+    @PreUpdate
+    void preUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    /* ====================== 상태 전이 헬퍼 ====================== */
+
+    public void markRunning() {
+        status = JobStatus.RUNNING;
+    }
+
+    public void succeed(Long resultFileId) {
+        status = JobStatus.SUCCEEDED;
+        this.resultFileId = resultFileId;
+    }
+
+    public void fail(String msg) {
+        status = JobStatus.FAILED;
+        this.errorMessage = msg;
+    }
+
+    /* ====================== 합성 파라미터 세팅 ====================== */
+
+    /** compose enqueue 시 편의 메서드 */
+    public void setComposeParams(String prompt, GenerationMode mode) {
+        this.prompt = prompt;
+        this.mode = mode;
+    }
+
+    /* ====================== 팩토리 메서드(편의) ====================== */
+
+    /** 합성 잡 생성 */
+    public static GenerationJob createComposeJob(Long ownerId, Long inputFileId) {
+        return GenerationJob.builder()
+                .ownerId(ownerId)
+                .type(JobType.COMPOSE)
+                .inputFileId(inputFileId)
+                .status(JobStatus.PENDING)
+                .retryCount(0)
+                .build();
+    }
+
+    /** 누끼 잡 생성(필요 시 사용) */
+    public static GenerationJob createRemoveBgJob(Long ownerId, Long inputFileId) {
+        return GenerationJob.builder()
+                .ownerId(ownerId)
+                .type(JobType.REMOVE_BG)
+                .inputFileId(inputFileId)
+                .status(JobStatus.PENDING)
+                .retryCount(0)
+                .build();
+    }
+}

--- a/src/main/java/com/example/nomodel/generationjob/domain/model/GenerationMode.java
+++ b/src/main/java/com/example/nomodel/generationjob/domain/model/GenerationMode.java
@@ -1,0 +1,7 @@
+package com.example.nomodel.generationjob.domain.model;
+
+public enum GenerationMode {
+    SCENE,          // 배경/장면만 생성
+    SUBJECT,        // 인물(모델)만 생성
+    SUBJECT_SCENE   // 인물 + 배경 한 번에 생성
+}

--- a/src/main/java/com/example/nomodel/generationjob/domain/model/JobStatus.java
+++ b/src/main/java/com/example/nomodel/generationjob/domain/model/JobStatus.java
@@ -1,0 +1,3 @@
+package com.example.nomodel.generationjob.domain.model;
+
+public enum JobStatus { PENDING, RUNNING, SUCCEEDED, FAILED }

--- a/src/main/java/com/example/nomodel/generationjob/domain/model/JobType.java
+++ b/src/main/java/com/example/nomodel/generationjob/domain/model/JobType.java
@@ -1,0 +1,3 @@
+package com.example.nomodel.generationjob.domain.model;
+
+public enum JobType { REMOVE_BG, COMPOSE }

--- a/src/main/java/com/example/nomodel/generationjob/domain/repository/GenerationJobRepository.java
+++ b/src/main/java/com/example/nomodel/generationjob/domain/repository/GenerationJobRepository.java
@@ -1,0 +1,7 @@
+package com.example.nomodel.generationjob.domain.repository;
+
+import com.example.nomodel.generationjob.domain.model.GenerationJob;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GenerationJobRepository extends JpaRepository<GenerationJob, UUID> {}

--- a/src/main/java/com/example/nomodel/removebg/application/controller/RemoveBgController.java
+++ b/src/main/java/com/example/nomodel/removebg/application/controller/RemoveBgController.java
@@ -1,0 +1,25 @@
+package com.example.nomodel.removebg.application.controller;
+
+import com.example.nomodel.generationjob.application.service.GenerationJobService;
+import com.example.nomodel.removebg.application.dto.RemoveBgRequest;
+import com.example.nomodel.removebg.application.dto.RemoveBgResponse;
+import com.example.nomodel.removebg.application.service.RemoveBgService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/generate")
+@RequiredArgsConstructor
+public class RemoveBgController {
+
+    private final RemoveBgService app;
+
+    @PostMapping("/remove-bg")
+    public ResponseEntity<?> remove(@RequestBody RemoveBgRequest req,
+                                    @RequestHeader(name="X-User-Id", required=false) Long userId) {
+        // 임시: 인증 붙기 전까지 헤더로 넘기거나 0L로 대체
+        var jobId = app.enqueue(userId == null ? 0L : userId, req.fileId());
+        return ResponseEntity.accepted().body(new RemoveBgResponse(jobId));
+    }
+}

--- a/src/main/java/com/example/nomodel/removebg/application/dto/RemoveBgRequest.java
+++ b/src/main/java/com/example/nomodel/removebg/application/dto/RemoveBgRequest.java
@@ -1,0 +1,3 @@
+package com.example.nomodel.removebg.application.dto;
+
+public record RemoveBgRequest(Long fileId) {}

--- a/src/main/java/com/example/nomodel/removebg/application/dto/RemoveBgResponse.java
+++ b/src/main/java/com/example/nomodel/removebg/application/dto/RemoveBgResponse.java
@@ -1,0 +1,4 @@
+package com.example.nomodel.removebg.application.dto;
+
+import java.util.UUID;
+public record RemoveBgResponse(UUID jobId) {}

--- a/src/main/java/com/example/nomodel/removebg/application/service/RemoveBgService.java
+++ b/src/main/java/com/example/nomodel/removebg/application/service/RemoveBgService.java
@@ -1,0 +1,46 @@
+package com.example.nomodel.removebg.application.service;
+
+import com.example.nomodel.generationjob.application.service.GenerationJobService;
+import com.example.nomodel.removebg.application.service.provider.BackgroundRemovalService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class RemoveBgService {
+
+    private final GenerationJobService jobs;
+    private final BackgroundRemovalService provider;
+    private final ObjectMapper om;
+
+    @Transactional
+    public UUID enqueue(Long ownerId, Long fileId) {
+        Map<String, Object> params = Map.of("retry", 2); // 재시도 기본값
+        String paramsJson = write(params);
+
+        var job = jobs.enqueueRemoveBg(ownerId, fileId, paramsJson);
+
+        // 비동기 실행 (GenerationJobService 에서 @Async 로 실행)
+        jobs.runRemoveBg(job.getId(),
+                (inputFileId, opts) -> {
+                    try {
+                        return provider.removeBackground(inputFileId, opts);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                },
+                params
+        );
+
+        return job.getId();
+    }
+
+    private String write(Map<String, Object> m) {
+        try { return om.writeValueAsString(m); } catch (Exception e) { return "{}"; }
+    }
+}

--- a/src/main/java/com/example/nomodel/removebg/application/service/provider/BackgroundRemovalService.java
+++ b/src/main/java/com/example/nomodel/removebg/application/service/provider/BackgroundRemovalService.java
@@ -1,0 +1,7 @@
+package com.example.nomodel.removebg.application.service.provider;
+
+import java.util.Map;
+
+public interface BackgroundRemovalService {
+    Long removeBackground(Long originalFileId, Map<String, Object> opts) throws Exception;
+}

--- a/src/main/java/com/example/nomodel/removebg/application/service/provider/DummyBackgroundRemovalService.java
+++ b/src/main/java/com/example/nomodel/removebg/application/service/provider/DummyBackgroundRemovalService.java
@@ -1,0 +1,31 @@
+package com.example.nomodel.removebg.application.service.provider;
+
+import com.example.nomodel.file.application.service.FileService;
+import com.example.nomodel.file.domain.model.FileType;
+import com.example.nomodel.file.domain.model.RelationType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@ConditionalOnProperty(name = "BG_PROVIDER", havingValue = "dummy", matchIfMissing = true)
+@RequiredArgsConstructor
+public class DummyBackgroundRemovalService implements BackgroundRemovalService {
+
+    private final FileService fileService;
+
+    @Override
+    public Long removeBackground(Long originalFileId, Map<String, Object> opts) throws Exception {
+
+        byte[] original = fileService.loadAsBytes(originalFileId);
+        return fileService.saveBytes(
+                original,
+                "image/png",
+                RelationType.AD,
+                originalFileId,
+                FileType.PREVIEW
+        );
+    }
+}

--- a/src/main/java/com/example/nomodel/removebg/application/service/provider/GeminiBackgroundRemovalService.java
+++ b/src/main/java/com/example/nomodel/removebg/application/service/provider/GeminiBackgroundRemovalService.java
@@ -1,0 +1,61 @@
+package com.example.nomodel.removebg.application.service.provider;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import com.example.nomodel.file.application.service.FileService;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+
+@Service
+@org.springframework.boot.autoconfigure.condition.ConditionalOnProperty(name = "BG_PROVIDER", havingValue = "gemini")
+@RequiredArgsConstructor
+public class GeminiBackgroundRemovalService implements BackgroundRemovalService {
+
+    private final WebClient geminiWebClient;
+    private final FileService fileService;
+
+    @Value("${GEMINI_BG_MODEL:gemini-2.0-pro}")
+    private String model;
+
+    @Value("${BG_TIMEOUT_SEC:120}")
+    private long timeoutSec;
+
+    @Override
+    public Long removeBackground(Long originalFileId, Map<String,Object> opts) throws Exception {
+        // 1) 원본 파일 읽기
+        var original = fileService.loadAsBytes(originalFileId); // 바이트/메타 얻는 메서드는 FileService에 구현
+
+        // 2) Gemini 호출 (엔드포인트/바디는 팀이 실제 스펙에 맞춰 조정)
+        // 예시: /v1beta/models/{model}:media.edit (가상의 엔드포인트 이름, 실제로는 팀에서 사용 중인 게이트웨이/프록시와 맞추세요)
+        var respBytes = geminiWebClient.post()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/v1beta/models/{model}:media:removeBackground")
+                        .build(model))
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .bodyValue(original)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, r -> r.bodyToMono(String.class).flatMap(b ->
+                        Mono.error(new RuntimeException("Gemini error: " + b))))
+                .bodyToMono(byte[].class)
+                .timeout(Duration.ofSeconds(timeoutSec))
+                .retry((int) Integer.parseInt(String.valueOf(opts.getOrDefault("retry", 2))))
+                .block();
+
+        if (respBytes == null) throw new RuntimeException("Empty response from Gemini");
+
+        // 3) 결과 저장(type = REMOVED_BG) 후 id 반환
+        return fileService.saveBytes(
+                respBytes,
+                "image/png",
+                com.example.nomodel.file.domain.model.RelationType.AD,   // 임시: 광고 자산으로 묶기 (TODO: 필요하면 새 enum 추가)
+                originalFileId,
+                com.example.nomodel.file.domain.model.FileType.PREVIEW   // 임시: 제거본을 PREVIEW 로 저장
+        );
+    }
+}

--- a/src/main/java/com/example/nomodel/removebg/application/service/provider/RemoveBgBackgroundRemovalService.java
+++ b/src/main/java/com/example/nomodel/removebg/application/service/provider/RemoveBgBackgroundRemovalService.java
@@ -1,0 +1,75 @@
+package com.example.nomodel.removebg.application.service.provider;
+
+import com.example.nomodel.file.application.service.FileService;
+import com.example.nomodel.file.domain.model.FileType;
+import com.example.nomodel.file.domain.model.RelationType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.Map;
+
+@Slf4j
+@Service
+@ConditionalOnProperty(name = "BG_PROVIDER", havingValue = "removebg")
+@RequiredArgsConstructor
+public class RemoveBgBackgroundRemovalService implements BackgroundRemovalService {
+
+    // (선택) 동일 타입 WebClient가 여러 개인 프로젝트에서 보다 명확하게 주입
+    private final @Qualifier("removeBgWebClient") WebClient removeBgWebClient;
+
+    private final FileService fileService;
+
+    @Override
+    public Long removeBackground(Long originalFileId, Map<String, Object> opts) throws Exception {
+        // 1) 원본 로드
+        byte[] original = fileService.loadAsBytes(originalFileId);
+
+        // 2) form-data 구성
+        MultipartBodyBuilder mb = new MultipartBodyBuilder();
+        mb.part("image_file", original)
+                .filename("input.png")
+                .contentType(MediaType.APPLICATION_OCTET_STREAM);
+
+        // 옵션: size/format (bg_color는 기본 투명이라 전송하지 않음)
+        String size = String.valueOf(opts.getOrDefault("size", "auto"));     // auto | preview | small | medium | hd | 4k (요금제에 따라 상이)
+        String format = String.valueOf(opts.getOrDefault("format", "png"));  // 투명 유지 위해 png 권장
+
+        mb.part("size", size);
+        mb.part("format", format);
+
+        int retry = Integer.parseInt(String.valueOf(opts.getOrDefault("retry", 1)));
+        long timeoutSec = Long.parseLong(String.valueOf(opts.getOrDefault("timeoutSec", 60)));
+
+        log.info("[remove.bg] call start: fileId={}, size={}, format={}", originalFileId, size, format);
+
+        // 3) 호출
+        byte[] out = removeBgWebClient.post()
+                .uri(uriBuilder -> uriBuilder.path("/v1.0/removebg").build())
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .bodyValue(mb.build())
+                .retrieve()
+                .onStatus(s -> !s.is2xxSuccessful(), r -> r.bodyToMono(String.class)
+                        .flatMap(body -> Mono.error(new RuntimeException("remove.bg error: " + body))))
+                .bodyToMono(byte[].class)
+                .timeout(Duration.ofSeconds(timeoutSec))
+                .retry(retry)
+                .block();
+
+        if (out == null || out.length == 0) {
+            throw new RuntimeException("remove.bg empty response");
+        }
+
+        // 4) 저장
+        Long resultId = fileService.saveBytes(out, "image/png", RelationType.AD, originalFileId, FileType.PREVIEW);
+        log.info("[remove.bg] succeed: originalFileId={} -> resultFileId={}", originalFileId, resultId);
+        return resultId;
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  config:
+    import: optional:file:.env[.properties]


### PR DESCRIPTION
- 이미지 배경 제거 작동 완료
- 생성/합성 파이프라인 초기 구현 (현재 더미로 작동)
- 생성부터 실제 API로 작동하게 변경해야함

## ⭐Key Changes
> 핵심 변경 사항에 대해서 적어주세요.
1. GenerationJob 엔티티 작성 (Job ID, 타입, 상태, 파라미터, 결과 파일 관리)
2. JobType, JobStatus, GenerationMode enum 생성
3. ImageGenerator 인터페이스 설계 + Dummy 구현체 작성
4. ImageCompositor 인터페이스 설계 + Dummy 구현체 작성
5. Bean 주입 오류 해결 (@service + @ConditionalOnProperty 조합 적용)
6. DB 마이그레이션 반영 완료 (generation_job 테이블 ALTER 확인)

<br>

## 📌Issue
> "close #이슈번호"로 해당 이슈 완료해주세요.

<br>

## 👪To Reviewers
> reviewer 에게 하고 싶은 말을 적어주세요.

<br>

## 🐾Next Move
> 다음 개발 목표를 적어주세요
1. DummyImageGenerator → 실제 이미지 생성 API(Replicate, Stability, ComfyUI 등) 연결
2. 합성 API 연동 (ImageCompositor 실제 구현체 작성, 인페인팅/마스킹 기반)
3. ComposeController 작성 → 사용자 요청 시 enqueueCompose() 호출
4. 합성 단계 완성 (runCompose()에서 cutout(product) + scene 합성 후 저장)
5. 프론트엔드 연동 (업로드/프롬프트 입력/결과 조회 UI)
