### PR TITLE
Feat 51: 마이페이지 내 리뷰 조회/수정/삭제 API 구현, Subscrpitoin관련 타입 오류 해결

### DIFF
--- a/src/main/java/com/example/nomodel/review/application/controller/MyReviewController.java
+++ b/src/main/java/com/example/nomodel/review/application/controller/MyReviewController.java
@@ -1,0 +1,104 @@
+package com.example.nomodel.review.application.controller;
+
+import com.example.nomodel.review.application.dto.request.ReviewRequest;
+import com.example.nomodel.review.application.dto.response.ReviewResponse;
+import com.example.nomodel.review.application.service.ReviewService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "My Reviews API", description = "내가 작성한 리뷰 관리 API")
+@RestController
+@RequestMapping("/me/reviews")
+@RequiredArgsConstructor
+public class MyReviewController {
+
+    private final ReviewService reviewService;
+
+    /**
+     * 내가 작성한 모든 리뷰 조회
+     */
+    @Operation(summary = "내가 작성한 모든 리뷰 조회", description = "로그인한 사용자가 작성한 모든 리뷰를 조회합니다.")
+    @GetMapping
+    public ResponseEntity<List<ReviewResponse>> getMyAllReviews(
+            @AuthenticationPrincipal(expression = "memberId") Long reviewerId
+    ) {
+        List<ReviewResponse> myReviews = reviewService.getMyAllReviews(reviewerId);
+        return ResponseEntity.ok(myReviews);
+    }
+
+    /**
+     * 내가 작성한 특정 리뷰 조회
+     */
+    @Operation(summary = "내 특정 리뷰 조회", description = "내가 작성한 특정 리뷰를 조회합니다.")
+    @GetMapping("/{reviewId}")
+    public ResponseEntity<ReviewResponse> getMyReview(
+            @PathVariable Long reviewId,
+            @AuthenticationPrincipal(expression = "memberId") Long reviewerId
+    ) {
+        ReviewResponse myReview = reviewService.getMyReview(reviewerId, reviewId);
+        return ResponseEntity.ok(myReview);
+    }
+
+    /**
+     * 내가 작성한 리뷰 수정
+     */
+    @Operation(summary = "내 리뷰 수정", description = "내가 작성한 리뷰를 수정합니다.")
+    @PutMapping("/{reviewId}")
+    public ResponseEntity<ReviewResponse> updateMyReview(
+            @PathVariable Long reviewId,
+            @AuthenticationPrincipal(expression = "memberId") Long reviewerId,
+            @RequestBody ReviewRequest request
+    ) {
+        ReviewResponse updated = reviewService.updateMyReview(reviewerId, reviewId, request);
+        return ResponseEntity.ok(updated);
+    }
+
+    /**
+     * 내가 작성한 리뷰 삭제
+     */
+    @Operation(summary = "내 리뷰 삭제", description = "내가 작성한 리뷰를 삭제합니다.")
+    @DeleteMapping("/{reviewId}")
+    public ResponseEntity<Void> deleteMyReview(
+            @PathVariable Long reviewId,
+            @AuthenticationPrincipal(expression = "memberId") Long reviewerId
+    ) {
+        reviewService.deleteMyReview(reviewerId, reviewId);
+        return ResponseEntity.noContent().build(); // 204 No Content
+    }
+}
+
+// ReviewService에 추가 필요한 메서드들
+/*
+public class ReviewService {
+
+    // 내가 작성한 모든 리뷰 조회
+    public List<ReviewResponse> getMyAllReviews(Long reviewerId) {
+        // reviewerId로 모든 활성 리뷰 조회
+        // ReviewStatus.ACTIVE인 것만 필터링
+    }
+
+    // 내가 작성한 특정 리뷰 조회 (권한 체크 포함)
+    public ReviewResponse getMyReview(Long reviewerId, Long reviewId) {
+        // reviewId로 리뷰 조회 후 reviewerId 일치 여부 확인
+        // 권한이 없으면 예외 처리
+    }
+
+    // 내가 작성한 리뷰 수정 (권한 체크 포함)
+    public ReviewResponse updateMyReview(Long reviewerId, Long reviewId, ReviewRequest request) {
+        // reviewId로 리뷰 조회 후 reviewerId 일치 여부 확인
+        // 권한이 있으면 수정, 없으면 예외 처리
+    }
+
+    // 내가 작성한 리뷰 삭제 (권한 체크 포함)
+    public void deleteMyReview(Long reviewerId, Long reviewId) {
+        // reviewId로 리뷰 조회 후 reviewerId 일치 여부 확인
+        // 권한이 있으면 삭제(status 변경), 없으면 예외 처리
+    }
+}
+*/

--- a/src/main/java/com/example/nomodel/review/application/controller/MyReviewController.java
+++ b/src/main/java/com/example/nomodel/review/application/controller/MyReviewController.java
@@ -1,5 +1,6 @@
 package com.example.nomodel.review.application.controller;
 
+import com.example.nomodel._core.utils.ApiUtils;
 import com.example.nomodel.review.application.dto.request.ReviewRequest;
 import com.example.nomodel.review.application.dto.response.ReviewResponse;
 import com.example.nomodel.review.application.service.ReviewService;
@@ -25,11 +26,11 @@ public class MyReviewController {
      */
     @Operation(summary = "내가 작성한 모든 리뷰 조회", description = "로그인한 사용자가 작성한 모든 리뷰를 조회합니다.")
     @GetMapping
-    public ResponseEntity<List<ReviewResponse>> getMyAllReviews(
+    public ResponseEntity<ApiUtils.ApiResult<List<ReviewResponse>>> getMyAllReviews(
             @AuthenticationPrincipal(expression = "memberId") Long reviewerId
     ) {
         List<ReviewResponse> myReviews = reviewService.getMyAllReviews(reviewerId);
-        return ResponseEntity.ok(myReviews);
+        return ResponseEntity.ok(ApiUtils.success(myReviews));
     }
 
     /**
@@ -37,12 +38,12 @@ public class MyReviewController {
      */
     @Operation(summary = "내 특정 리뷰 조회", description = "내가 작성한 특정 리뷰를 조회합니다.")
     @GetMapping("/{reviewId}")
-    public ResponseEntity<ReviewResponse> getMyReview(
+    public ResponseEntity<ApiUtils.ApiResult<ReviewResponse>> getMyReview(
             @PathVariable Long reviewId,
             @AuthenticationPrincipal(expression = "memberId") Long reviewerId
     ) {
         ReviewResponse myReview = reviewService.getMyReview(reviewerId, reviewId);
-        return ResponseEntity.ok(myReview);
+        return ResponseEntity.ok(ApiUtils.success(myReview));
     }
 
     /**
@@ -50,13 +51,13 @@ public class MyReviewController {
      */
     @Operation(summary = "내 리뷰 수정", description = "내가 작성한 리뷰를 수정합니다.")
     @PutMapping("/{reviewId}")
-    public ResponseEntity<ReviewResponse> updateMyReview(
+    public ResponseEntity<ApiUtils.ApiResult<ReviewResponse>> updateMyReview(
             @PathVariable Long reviewId,
             @AuthenticationPrincipal(expression = "memberId") Long reviewerId,
             @RequestBody ReviewRequest request
     ) {
         ReviewResponse updated = reviewService.updateMyReview(reviewerId, reviewId, request);
-        return ResponseEntity.ok(updated);
+        return ResponseEntity.ok(ApiUtils.success(updated));
     }
 
     /**
@@ -64,41 +65,12 @@ public class MyReviewController {
      */
     @Operation(summary = "내 리뷰 삭제", description = "내가 작성한 리뷰를 삭제합니다.")
     @DeleteMapping("/{reviewId}")
-    public ResponseEntity<Void> deleteMyReview(
+    public ResponseEntity<ApiUtils.ApiResult<Void>> deleteMyReview(
             @PathVariable Long reviewId,
             @AuthenticationPrincipal(expression = "memberId") Long reviewerId
     ) {
         reviewService.deleteMyReview(reviewerId, reviewId);
-        return ResponseEntity.noContent().build(); // 204 No Content
+        // 204 대신 200 OK와 success 메시지 반환
+        return ResponseEntity.ok(ApiUtils.success(null));
     }
 }
-
-// ReviewService에 추가 필요한 메서드들
-/*
-public class ReviewService {
-
-    // 내가 작성한 모든 리뷰 조회
-    public List<ReviewResponse> getMyAllReviews(Long reviewerId) {
-        // reviewerId로 모든 활성 리뷰 조회
-        // ReviewStatus.ACTIVE인 것만 필터링
-    }
-
-    // 내가 작성한 특정 리뷰 조회 (권한 체크 포함)
-    public ReviewResponse getMyReview(Long reviewerId, Long reviewId) {
-        // reviewId로 리뷰 조회 후 reviewerId 일치 여부 확인
-        // 권한이 없으면 예외 처리
-    }
-
-    // 내가 작성한 리뷰 수정 (권한 체크 포함)
-    public ReviewResponse updateMyReview(Long reviewerId, Long reviewId, ReviewRequest request) {
-        // reviewId로 리뷰 조회 후 reviewerId 일치 여부 확인
-        // 권한이 있으면 수정, 없으면 예외 처리
-    }
-
-    // 내가 작성한 리뷰 삭제 (권한 체크 포함)
-    public void deleteMyReview(Long reviewerId, Long reviewId) {
-        // reviewId로 리뷰 조회 후 reviewerId 일치 여부 확인
-        // 권한이 있으면 삭제(status 변경), 없으면 예외 처리
-    }
-}
-*/

--- a/src/main/java/com/example/nomodel/review/application/controller/ReviewController.java
+++ b/src/main/java/com/example/nomodel/review/application/controller/ReviewController.java
@@ -43,7 +43,7 @@ public class ReviewController {
     //리뷰 수정 Controller 엔드포인트
     @Operation(summary = "리뷰 수정", description = "특정 리뷰를 수정합니다.")
     @PutMapping("/{reviewId}")
-    public ResponseEntity <ApiUtils.ApiResult<ReviewResponse>> updateReview(
+    public ResponseEntity<ApiUtils.ApiResult<ReviewResponse>> updateReview(
             @PathVariable Long modelId,
             @PathVariable Long reviewId,
             @AuthenticationPrincipal(expression = "memberId") Long reviewerId,
@@ -64,69 +64,4 @@ public class ReviewController {
         ReviewResponse deleted = reviewService.deleteReview(reviewerId, reviewId);
         return ResponseEntity.ok(ApiUtils.success(deleted));
     }
-
-    // 새로 추가된 내 리뷰 관리 API들 (ResponseEntity 사용)
-
-    /**
-     * 특정 모델에서 내가 작성한 리뷰 조회
-     */
-    @Operation(summary = "내 리뷰 조회", description = "특정 모델에서 내가 작성한 리뷰를 조회합니다.")
-    @GetMapping("/me")
-    public ResponseEntity<ReviewResponse> getMyReview(
-            @PathVariable Long modelId,
-            @AuthenticationPrincipal(expression = "memberId") Long reviewerId
-    ) {
-        ReviewResponse myReview = reviewService.getMyReviewByModel(reviewerId, modelId);
-        return ResponseEntity.ok(myReview);
-    }
-
-    /**
-     * 특정 모델에서 내 리뷰 수정
-     */
-    @Operation(summary = "내 리뷰 수정", description = "특정 모델에서 내가 작성한 리뷰를 수정합니다.")
-    @PutMapping("/me")
-    public ResponseEntity<ReviewResponse> updateMyReview(
-            @PathVariable Long modelId,
-            @AuthenticationPrincipal(expression = "memberId") Long reviewerId,
-            @RequestBody ReviewRequest request
-    ) {
-        ReviewResponse updated = reviewService.updateMyReviewByModel(reviewerId, modelId, request);
-        return ResponseEntity.ok(updated);
-    }
-
-    /**
-     * 특정 모델에서 내 리뷰 삭제
-     */
-    @Operation(summary = "내 리뷰 삭제", description = "특정 모델에서 내가 작성한 리뷰를 삭제합니다.")
-    @DeleteMapping("/me")
-    public ResponseEntity<Void> deleteMyReview(
-            @PathVariable Long modelId,
-            @AuthenticationPrincipal(expression = "memberId") Long reviewerId
-    ) {
-        reviewService.deleteMyReviewByModel(reviewerId, modelId);
-        return ResponseEntity.noContent().build(); // 204 No Content
-    }
 }
-
-// 추가로 필요한 ReviewService 메서드들 (구현 필요)
-/*
-public class ReviewService {
-
-    // 기존 메서드들...
-
-    public ReviewResponse getMyReviewByModel(Long reviewerId, Long modelId) {
-        // reviewerId와 modelId로 내 리뷰 조회
-        // 리뷰가 없으면 적절한 예외 처리
-    }
-
-    public ReviewResponse updateMyReviewByModel(Long reviewerId, Long modelId, ReviewRequest request) {
-        // reviewerId와 modelId로 내 리뷰 찾아서 수정
-        // 권한 체크 및 존재 여부 확인
-    }
-
-    public ReviewResponse deleteMyReviewByModel(Long reviewerId, Long modelId) {
-        // reviewerId와 modelId로 내 리뷰 찾아서 삭제 (status 변경)
-        // 권한 체크 및 존재 여부 확인
-    }
-}
-*/

--- a/src/main/java/com/example/nomodel/review/application/controller/ReviewController.java
+++ b/src/main/java/com/example/nomodel/review/application/controller/ReviewController.java
@@ -65,7 +65,68 @@ public class ReviewController {
         return ResponseEntity.ok(ApiUtils.success(deleted));
     }
 
+    // 새로 추가된 내 리뷰 관리 API들 (ResponseEntity 사용)
 
+    /**
+     * 특정 모델에서 내가 작성한 리뷰 조회
+     */
+    @Operation(summary = "내 리뷰 조회", description = "특정 모델에서 내가 작성한 리뷰를 조회합니다.")
+    @GetMapping("/me")
+    public ResponseEntity<ReviewResponse> getMyReview(
+            @PathVariable Long modelId,
+            @AuthenticationPrincipal(expression = "memberId") Long reviewerId
+    ) {
+        ReviewResponse myReview = reviewService.getMyReviewByModel(reviewerId, modelId);
+        return ResponseEntity.ok(myReview);
+    }
 
+    /**
+     * 특정 모델에서 내 리뷰 수정
+     */
+    @Operation(summary = "내 리뷰 수정", description = "특정 모델에서 내가 작성한 리뷰를 수정합니다.")
+    @PutMapping("/me")
+    public ResponseEntity<ReviewResponse> updateMyReview(
+            @PathVariable Long modelId,
+            @AuthenticationPrincipal(expression = "memberId") Long reviewerId,
+            @RequestBody ReviewRequest request
+    ) {
+        ReviewResponse updated = reviewService.updateMyReviewByModel(reviewerId, modelId, request);
+        return ResponseEntity.ok(updated);
+    }
 
+    /**
+     * 특정 모델에서 내 리뷰 삭제
+     */
+    @Operation(summary = "내 리뷰 삭제", description = "특정 모델에서 내가 작성한 리뷰를 삭제합니다.")
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> deleteMyReview(
+            @PathVariable Long modelId,
+            @AuthenticationPrincipal(expression = "memberId") Long reviewerId
+    ) {
+        reviewService.deleteMyReviewByModel(reviewerId, modelId);
+        return ResponseEntity.noContent().build(); // 204 No Content
+    }
 }
+
+// 추가로 필요한 ReviewService 메서드들 (구현 필요)
+/*
+public class ReviewService {
+
+    // 기존 메서드들...
+
+    public ReviewResponse getMyReviewByModel(Long reviewerId, Long modelId) {
+        // reviewerId와 modelId로 내 리뷰 조회
+        // 리뷰가 없으면 적절한 예외 처리
+    }
+
+    public ReviewResponse updateMyReviewByModel(Long reviewerId, Long modelId, ReviewRequest request) {
+        // reviewerId와 modelId로 내 리뷰 찾아서 수정
+        // 권한 체크 및 존재 여부 확인
+    }
+
+    public ReviewResponse deleteMyReviewByModel(Long reviewerId, Long modelId) {
+        // reviewerId와 modelId로 내 리뷰 찾아서 삭제 (status 변경)
+        // 권한 체크 및 존재 여부 확인
+    }
+}
+*/

--- a/src/main/java/com/example/nomodel/review/application/service/ReviewService.java
+++ b/src/main/java/com/example/nomodel/review/application/service/ReviewService.java
@@ -121,6 +121,94 @@ public class ReviewService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * 내가 작성한 특정 리뷰 조회 (권한 체크 포함)
+     */
+    @Transactional(readOnly = true)
+    public ReviewResponse getMyReview(Long reviewerId, Long reviewId) {
+        ModelReview review = reviewRepository.findByIdAndReviewerId(reviewId, reviewerId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.REVIEW_NOT_FOUND));
 
+        // 삭제된 리뷰는 조회 불가
+        if (review.getStatus() == ReviewStatus.DELETED) {
+            throw new ApplicationException(ErrorCode.REVIEW_NOT_FOUND);
+        }
+
+        return ReviewResponse.from(review);
+    }
+
+    /**
+     * 내가 작성한 리뷰 수정 (권한 체크 포함)
+     */
+    @Transactional
+    public ReviewResponse updateMyReview(Long reviewerId, Long reviewId, ReviewRequest request) {
+        ModelReview review = reviewRepository.findByIdAndReviewerId(reviewId, reviewerId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.REVIEW_NOT_FOUND));
+
+        // 삭제된 리뷰 수정 불가
+        if (review.getStatus() == ReviewStatus.DELETED) {
+            throw new ApplicationException(ErrorCode.REVIEW_NOT_ALLOWED);
+        }
+
+        // 리뷰 내용 업데이트
+        review.update(
+                new Rating(request.getRating()),
+                request.getContent()
+        );
+
+        return ReviewResponse.from(reviewRepository.save(review));
+    }
+
+
+    //내가 작성한 리뷰 삭제(권한 포함)
+    @Transactional
+    public void deleteMyReview(Long reviewerId, Long reviewId) {
+        ModelReview review = reviewRepository.findByIdAndReviewerId(reviewId, reviewerId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.REVIEW_NOT_FOUND));
+
+        review.deactivate(ReviewStatus.DELETED);
+        reviewRepository.save(review);
+    }
+
+
+   // 특정 모델에서 내가 작성한 리뷰 조회
+
+    @Transactional(readOnly = true)
+    public ReviewResponse getMyReviewByModel(Long reviewerId, Long modelId) {
+        ModelReview review = reviewRepository.findByReviewerIdAndModelIdAndStatus(
+                reviewerId, modelId, ReviewStatus.ACTIVE
+        ).orElseThrow(() -> new ApplicationException(ErrorCode.REVIEW_NOT_FOUND));
+
+        return ReviewResponse.from(review);
+    }
+
+
+     //특정 모델에서 내 리뷰 수정
+    @Transactional
+    public ReviewResponse updateMyReviewByModel(Long reviewerId, Long modelId, ReviewRequest request) {
+        ModelReview review = reviewRepository.findByReviewerIdAndModelIdAndStatus(
+                reviewerId, modelId, ReviewStatus.ACTIVE
+        ).orElseThrow(() -> new ApplicationException(ErrorCode.REVIEW_NOT_FOUND));
+
+        // 리뷰 내용 업데이트
+        review.update(
+                new Rating(request.getRating()),
+                request.getContent()
+        );
+
+        return ReviewResponse.from(reviewRepository.save(review));
+    }
+
+
+     //특정 모델에서 내 리뷰 삭제
+    @Transactional
+    public void deleteMyReviewByModel(Long reviewerId, Long modelId) {
+        ModelReview review = reviewRepository.findByReviewerIdAndModelIdAndStatus(
+                reviewerId, modelId, ReviewStatus.ACTIVE
+        ).orElseThrow(() -> new ApplicationException(ErrorCode.REVIEW_NOT_FOUND));
+
+        review.deactivate(ReviewStatus.DELETED);
+        reviewRepository.save(review);
+    }
 }
 

--- a/src/main/java/com/example/nomodel/review/application/service/ReviewService.java
+++ b/src/main/java/com/example/nomodel/review/application/service/ReviewService.java
@@ -106,5 +106,21 @@ public class ReviewService {
 
         return ReviewResponse.from(deleted);
     }
+
+    //내가 작성한 모든 리뷰 조회
+    @Transactional(readOnly = true)
+    public List<ReviewResponse> getMyAllReviews(Long reviewerId) {
+        // ACTIVE 상태인 내가 작성한 모든 리뷰 조회 (최신순 정렬)
+        List<ModelReview> myReviews = reviewRepository.findByReviewerIdAndStatusOrderByCreatedAtDesc(
+                reviewerId,
+                ReviewStatus.ACTIVE
+        );
+
+        return myReviews.stream()
+                .map(ReviewResponse::from)
+                .collect(Collectors.toList());
+    }
+
+
 }
 

--- a/src/main/java/com/example/nomodel/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/example/nomodel/review/domain/repository/ReviewRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<ModelReview, Long> {
     // 모델별 리뷰 조회
@@ -62,5 +63,14 @@ public interface ReviewRepository extends JpaRepository<ModelReview, Long> {
      * 특정 사용자가 작성한 특정 상태의 리뷰들을 최신순으로 조회
      */
     List<ModelReview> findByReviewerIdAndStatusOrderByCreatedAtDesc(Long reviewerId, ReviewStatus status);
+    /**
+     * 특정 리뷰 ID와 작성자 ID로 조회 (권한 체크용)
+     */
+    Optional<ModelReview> findByIdAndReviewerId(Long reviewId, Long reviewerId);
+
+    /**
+     * 특정 사용자가 특정 모델에 작성한 특정 상태의 리뷰 조회
+     */
+    Optional<ModelReview> findByReviewerIdAndModelIdAndStatus(Long reviewerId, Long modelId, ReviewStatus status);
 }
 

--- a/src/main/java/com/example/nomodel/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/example/nomodel/review/domain/repository/ReviewRepository.java
@@ -55,5 +55,12 @@ public interface ReviewRepository extends JpaRepository<ModelReview, Long> {
      */
     @Query("SELECT r.modelId, COUNT(r), AVG(r.rating.value) FROM ModelReview r WHERE r.modelId IN :modelIds AND r.status = :status GROUP BY r.modelId")
     List<Object[]> getReviewStatisticsByModelIds(@Param("modelIds") List<Long> modelIds, @Param("status") ReviewStatus status);
+
+    // ReviewRepository 인터페이스에 추가할 메서드
+
+    /**
+     * 특정 사용자가 작성한 특정 상태의 리뷰들을 최신순으로 조회
+     */
+    List<ModelReview> findByReviewerIdAndStatusOrderByCreatedAtDesc(Long reviewerId, ReviewStatus status);
 }
 

--- a/src/main/java/com/example/nomodel/subscription/application/dto/response/SubscriptionResponse.java
+++ b/src/main/java/com/example/nomodel/subscription/application/dto/response/SubscriptionResponse.java
@@ -8,9 +8,9 @@ public class SubscriptionResponse {
     private PlanType planType;
     private String description;
     private BigDecimal price;
-    private Long period; // 일 단위니까 Long이 더 자연스러움
+    private Integer period; //
 
-    public SubscriptionResponse(Long id, PlanType planType, String description, BigDecimal price, Long period) {
+    public SubscriptionResponse(Long id, PlanType planType, String description, BigDecimal price, Integer period) {
         this.id = id;
         this.planType = planType;
         this.description = description;
@@ -22,5 +22,5 @@ public class SubscriptionResponse {
     public PlanType getPlanType() { return planType; }
     public String getDescription() { return description; }
     public BigDecimal getPrice() { return price; }
-    public Long getPeriod() { return period; }
+    public Integer getPeriod() { return period; }
 }

--- a/src/main/java/com/example/nomodel/subscription/application/service/SubscriptionService.java
+++ b/src/main/java/com/example/nomodel/subscription/application/service/SubscriptionService.java
@@ -30,7 +30,7 @@ public class SubscriptionService {
                         s.getPlanType(),
                         s.getDescription(),
                         s.getPrice(),
-                        s.getPeriod()
+                        s.getPeriod()    //Integer을 Long으로 변환
                 ))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/example/nomodel/subscription/domain/model/Subscription.java
+++ b/src/main/java/com/example/nomodel/subscription/domain/model/Subscription.java
@@ -35,7 +35,7 @@ public class Subscription {
     public Long getId() { return id; }
     public PlanType getPlanType() { return planType; }
     public String getDescription() { return description; }
-    public Long getPeriod() { return period; }
+    public Integer getPeriod() { return period; }
     public Integer getDailyLimit() { return dailyLimit; }
     public BigDecimal getPrice() { return price; }
     public Integer getSelfMadeModelNum() { return selfMadeModelNum; }


### PR DESCRIPTION
📌 관련 커밋

fix: Subscription period 타입 Integer로 통일

feat: 내 리뷰 전체 조회 API 구현

feat: 내 리뷰 전체 조회, 특정 리뷰만 조회, 특정 리뷰 삭제, 특정 리뷰 수정 API 구현


📝 작업 내용

내 리뷰 전체 조회 API 구현

특정 리뷰 조회 API 구현

특정 리뷰 삭제 API 구현

특정 리뷰 수정 API 구현

마이페이지에서 내 리뷰를 조회, 수정, 삭제할 수 있는 기능을 위해 개발


⚠️ 특이 사항

리뷰 컨트롤러에서 현재 ApiUtils 기반으로 응답을 구성하고 있어, ResponseEntity로 리팩토링하지 못한 상태


✅ 목적

마이페이지에서 사용자가 자신의 리뷰를 조회·수정·삭제할 수 있는 기능 제공


🔗 참고 사항

후속 작업에서 ResponseEntity로의 전환 및 공통 응답 처리 방식 통일 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 내 리뷰 관리 기능 추가: 내 리뷰 전체 조회, 단건 조회, 수정, 삭제를 지원합니다 (/me/reviews).
- 리팩터링
  - 구독 정보의 “기간” 데이터 타입을 Integer로 통일하여 표시 일관성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->