### PR TITLE
fix: FileInfo - isPrimary 명시적 키 지정

### DIFF
--- a/src/main/java/com/example/nomodel/model/command/application/dto/AIModelDetailResponse.java
+++ b/src/main/java/com/example/nomodel/model/command/application/dto/AIModelDetailResponse.java
@@ -4,6 +4,7 @@ import com.example.nomodel.file.domain.model.File;
 import com.example.nomodel.model.command.domain.model.document.AIModelDocument;
 import com.example.nomodel.model.command.domain.model.AIModel;
 import com.example.nomodel.review.application.dto.response.ReviewResponse;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -51,6 +52,8 @@ public class AIModelDetailResponse {
         private Long fileId;
         private String fileUrl;
         private String fileName;
+
+        @JsonProperty("isPrimary")
         private boolean isPrimary;
 
         public static FileInfo from(File file) {


### PR DESCRIPTION
## ⭐Key Changes
> 핵심 변경 사항에 대해서 적어주세요.
1. 변경 사항 1
2. 변경 사항 2
3. ...

<br>

## 📌Issue
> "close #이슈번호"로 해당 이슈 완료해주세요.

<br>

## 👪To Reviewers
> reviewer 에게 하고 싶은 말을 적어주세요.

<br>

## 🐾Next Move
> 다음 개발 목표를 적어주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - API에서 FileInfo의 isPrimary 필드가 JSON으로 “isPrimary”라는 키로 일관되게 직렬화/역직렬화되도록 수정했습니다. 일부 환경에서 boolean 네이밍 규칙으로 “primary”로 노출되던 문제를 해소해, 클라이언트 파싱 오류를 방지하고 응답 호환성을 개선했습니다.
  - 기존 응답 스키마와의 불일치를 바로잡아, 프런트엔드·외부 연동에서 필드 매핑이 안정적으로 동작합니다. UI 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->