### PR TITLE
fix: 포인트 사용 중복제약 제거 및 리뷰 보상 전용 중복 방지 도입

### DIFF
--- a/src/main/java/com/example/nomodel/point/application/dto/request/PointUseRequest.java
+++ b/src/main/java/com/example/nomodel/point/application/dto/request/PointUseRequest.java
@@ -18,7 +18,7 @@ public class PointUseRequest {
     private BigDecimal amount;
 
     // 어디서 사용했는지 참조 ID (예: 주문 ID)
-    @NotNull(message = "참조 ID는 필수입니다.")   // ⭐ 필수 추가
+    @NotNull(message = "참조 ID는 필수입니다.")
     @Positive(message = "참조 ID는 양수여야 합니다.")
     private Long refererId;
 }

--- a/src/main/java/com/example/nomodel/point/domain/model/PointTransaction.java
+++ b/src/main/java/com/example/nomodel/point/domain/model/PointTransaction.java
@@ -9,11 +9,7 @@ import java.time.LocalDateTime;
         name = "point_transaction",
         indexes = {
                 @Index(name = "idx_point_transaction_created_at", columnList = "created_at")
-        },
-        uniqueConstraints = @UniqueConstraint(
-                name = "uq_tx_member_ref_type_ref_id_type",
-                columnNames = {"member_id","referer_type","referer_id","transaction_type"}
-        )
+        }
 )
 public class PointTransaction {
 

--- a/src/main/java/com/example/nomodel/point/domain/model/ReviewRewardTransaction.java
+++ b/src/main/java/com/example/nomodel/point/domain/model/ReviewRewardTransaction.java
@@ -1,0 +1,37 @@
+package com.example.nomodel.point.domain.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "review_reward_transaction",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_review_reward_member_model",
+                columnNames = {"member_id", "model_id"}
+        )
+)
+public class ReviewRewardTransaction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberId;
+    private Long modelId;
+    private LocalDateTime createdAt;
+
+    protected ReviewRewardTransaction() {}
+
+    public ReviewRewardTransaction(Long memberId, Long modelId) {
+        this.memberId = memberId;
+        this.modelId = modelId;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    // getter
+    public Long getId() { return id; }
+    public Long getMemberId() { return memberId; }
+    public Long getModelId() { return modelId; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+}

--- a/src/main/java/com/example/nomodel/point/domain/repository/ReviewRewardTransactionRepository.java
+++ b/src/main/java/com/example/nomodel/point/domain/repository/ReviewRewardTransactionRepository.java
@@ -1,0 +1,11 @@
+package com.example.nomodel.point.domain.repository;
+
+import com.example.nomodel.point.domain.model.ReviewRewardTransaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewRewardTransactionRepository extends JpaRepository<ReviewRewardTransaction, Long> {
+    
+    boolean existsByMemberIdAndModelId(Long memberId, Long modelId);
+}


### PR DESCRIPTION
## ⭐Key Changes
1. PointTransaction 엔티티 수정
기존의 유니크 제약조건을 제거했습니다
이제 포인트 사용(USE)에서 중복 사용이 가능합니다
<br>
2. 새로운 ReviewRewardTransaction 엔티티 생성
리뷰 보상에만 중복 방지를 적용하는 전용 테이블
member_id와 model_id의 조합으로 유니크 제약조건 적용
<br>
3. ReviewRewardTransactionRepository 생성
리뷰 보상 중복 체크를 위한 전용 리포지토리
<br>
4. PointService 수정
리뷰 보상 메서드에서 새로운 중복 체크 로직 적용
포인트 사용 메서드는 기존 그대로 유지 (중복 방지 없음)
<br>
결과
✅ 포인트 사용(USE): 중복 사용 가능
✅ 리뷰 보상(REWARD): 중복 방지 유지 (한 모델당 한 번만 보상)

<br>

## 📌Issue
> "close #122"로 해당 이슈 완료해주세요.

<br>

## 👪To Reviewers
> reviewer 에게 하고 싶은 말을 적어주세요.

<br>

## 🐾Next Move
> 다음 개발 목표를 적어주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 없음
* 버그 수정
  * 리뷰 보상 포인트가 드물게 중복 적립되거나 적립 실패로 처리되던 문제를 방지해 적립의 일관성과 신뢰성을 높였습니다.
  * 포인트 적립 처리 순서를 개선하여 보류 포인트의 가용 전환 과정에서 발생할 수 있는 오류 가능성을 줄였습니다.
* 작업
  * 내부 데이터 구조를 정비해 포인트 저장 충돌 가능성을 낮추고 운영 안정성과 모니터링 효율을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->